### PR TITLE
Added a Milestone filter field to Gitlab issue count widget

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1042,7 +1042,7 @@ var DashCI;
                         issue_count: {
                             method: 'GET',
                             isArray: false,
-                            url: globalOptions.gitlab.host + "/api/v3/:scope/:scopeId/issues?labels=:labels&state=:state&per_page=1",
+                            url: globalOptions.gitlab.host + "/api/v3/:scope/:scopeId/issues?labels=:labels&milestone=:milestone&state=:state&per_page=1",
                             headers: headers,
                             cache: false,
                             transformResponse: countParser
@@ -1577,6 +1577,7 @@ var DashCI;
                     this.data.color = this.data.color || "grey";
                     //default values
                     this.data.labels = this.data.labels || "bug";
+                    this.data.milestone = this.data.milestone || "";
                     this.data.status = this.data.status || "open";
                     this.data.poolInterval = this.data.poolInterval || 10000;
                     this.updateInterval();
@@ -1837,6 +1838,7 @@ var DashCI;
                         scope: this.data.query_type,
                         scopeId: this.data.query_type == 'projects' ? this.data.project : this.data.group,
                         labels: this.data.labels,
+                        milestone: this.data.milestone,
                         state: this.data.status
                     }).$promise.then(function (newCount) {
                         //var newCount = Math.round(Math.random() * 100);

--- a/src/app/resources/gitlab/resources.ts
+++ b/src/app/resources/gitlab/resources.ts
@@ -2,7 +2,7 @@
 
     export interface IGitlabResource extends ng.resource.IResourceClass<IGitlabObject> {
         project_list(): IProject[];
-        issue_count(param: { scope: string; scopeId: number; labels: string; state: string }): ICount;
+        issue_count(param: { scope: string; scopeId: number; labels: string; milestone: string; state: string }): ICount;
         latest_pipeline(param: { project: number; ref: string; }): IPipeline[];
         recent_pipelines(param: { project: number; ref: string; count: number }): IPipeline[];
         commit_count(param: { project: number; ref: string; since: string }): ICount;

--- a/src/app/widgets/gitlab-issues/config.html
+++ b/src/app/widgets/gitlab-issues/config.html
@@ -56,6 +56,10 @@
                             <md-option ng-value="opt.value" ng-repeat="opt in ctrl.intervals">{{ opt.desc }}</md-option>
                         </md-select>
                     </md-input-container>
+                    <md-input-container flex="80">
+                        <label>Milestone:</label>
+                        <input ng-model="ctrl.vm.milestone" placeholder="Type milestone name" type="text" />
+                    </md-input-container>
                 </div>
                 <div layout="row" layout-align="start" flex>
                     <md-input-container flex="80">


### PR DESCRIPTION
We are using Dash-CI to show a large amount of Gitlab based charts and issue counters. Since we are using Gitlab issue milestones to define our sprints we wanted to filter the issue counter on * labels and milestone X. 

I added this feature in this PR.