### PR TITLE
Update gitlab api from v3 to v4

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1176,14 +1176,14 @@ var DashCI;
                         latest_pipeline: {
                             method: 'GET',
                             isArray: true,
-                            url: globalOptions.gitlab.host + "/api/v3/projects/:project/pipelines?scope=branches&ref=:ref&per_page=100",
+                            url: globalOptions.gitlab.host + "/api/v4/projects/:project/pipelines?scope=branches&ref=:ref&per_page=100",
                             cache: false,
                             headers: headers
                         },
                         recent_pipelines: {
                             method: 'GET',
                             isArray: true,
-                            url: globalOptions.gitlab.host + "/api/v3/projects/:project/pipelines?ref=:ref&per_page=:count",
+                            url: globalOptions.gitlab.host + "/api/v4/projects/:project/pipelines?ref=:ref&per_page=:count",
                             cache: false,
                             headers: headers
                         },

--- a/src/app/resources/gitlab/resources.ts
+++ b/src/app/resources/gitlab/resources.ts
@@ -94,7 +94,7 @@
                 latest_pipeline: <ng.resource.IActionDescriptor>{
                     method: 'GET',
                     isArray: true,
-                    url: globalOptions.gitlab.host + "/api/v3/projects/:project/pipelines?scope=branches&ref=:ref&per_page=100",
+                    url: globalOptions.gitlab.host + "/api/v4/projects/:project/pipelines?scope=branches&ref=:ref&per_page=100",
                     cache: false,
                     headers: headers
                 },
@@ -102,7 +102,7 @@
                 recent_pipelines: <ng.resource.IActionDescriptor>{
                     method: 'GET',
                     isArray: true,
-                    url: globalOptions.gitlab.host + "/api/v3/projects/:project/pipelines?ref=:ref&per_page=:count",
+                    url: globalOptions.gitlab.host + "/api/v4/projects/:project/pipelines?ref=:ref&per_page=:count",
                     cache: false,
                     headers: headers
                 },


### PR DESCRIPTION
GitLab has deprecated the v3 api since GitLab 9.0 and has removed it in GitLab 11.0 breaking the dashboard, this PR simply changes the endpoint version.